### PR TITLE
Add interrupt controller for Aarch64.

### DIFF
--- a/vm-allocator/src/gsi.rs
+++ b/vm-allocator/src/gsi.rs
@@ -92,8 +92,11 @@ impl GsiAllocator {
 #[cfg(target_arch = "aarch64")]
 impl GsiAllocator {
     /// New GSI allocator
+    /// GSI starts from 32 for GICv2/3,
+    /// 32 irqs are reserved for legacy devices.
+    /// So the allocator should start from 32 + 32
     pub fn new() -> Self {
-        GsiAllocator { next_irq: 32 }
+        GsiAllocator { next_irq: 64 }
     }
 
     /// Allocate a GSI


### PR DESCRIPTION
To avoid spending too much effort in refactoring IOAPIC. I just used
Ioapic in devices/src/ioapic.rs as the interrupt controller. Even for
ARM, the name Ioapic is still used.

For X86, Ioapic is an emulated device; for ARM, it only provides a
function to inject interrupts.

Signed-off-by: Michael Zhao <michael.zhao@arm.com>