### PR TITLE
Integrate fdt code and fix cargo build

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -40,10 +40,11 @@ dependencies = [
  "acpi_tables 0.1.0",
  "arch_gen 0.1.0",
  "byteorder 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "device_tree 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "kvm-bindings 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "kvm-ioctls 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.68 (registry+https://github.com/rust-lang/crates.io-index)",
- "linux-loader 0.1.0 (git+https://github.com/rust-vmm/linux-loader)",
+ "linux-loader 0.1.0 (git+https://github.com/michael2012z/linux-loader.git?branch=crab2313-aarch64-image)",
  "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "vm-memory 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -212,6 +213,11 @@ dependencies = [
  "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "device_tree"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "devices"
@@ -466,7 +472,7 @@ dependencies = [
 [[package]]
 name = "linux-loader"
 version = "0.1.0"
-source = "git+https://github.com/rust-vmm/linux-loader#0ce5bfa70d1073a9743fadfea233edef09c81e49"
+source = "git+https://github.com/michael2012z/linux-loader.git?branch=crab2313-aarch64-image#02edb5b84660c32f2dac016bedcc99bf305ab314"
 dependencies = [
  "vm-memory 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1292,7 +1298,7 @@ dependencies = [
  "kvm-ioctls 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.68 (registry+https://github.com/rust-lang/crates.io-index)",
- "linux-loader 0.1.0 (git+https://github.com/rust-vmm/linux-loader)",
+ "linux-loader 0.1.0 (git+https://github.com/michael2012z/linux-loader.git?branch=crab2313-aarch64-image)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "micro_http 0.1.0 (git+https://github.com/firecracker-microvm/micro-http)",
  "net_util 0.1.0",
@@ -1385,6 +1391,7 @@ dependencies = [
 "checksum constant_time_eq 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
 "checksum credibility 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "fae7a162fd5b462bc49704873a89950a655d44161add4be07e00e64c4c83a5bf"
 "checksum crossbeam-utils 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)" = "c3c7c73a2d1e9fc0886a08b93e98eb643461230d5f1925e4036204d5f2e261a8"
+"checksum device_tree 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f18f717c5c7c2e3483feb64cccebd077245ad6d19007c2db0fd341d38595353c"
 "checksum dirs 2.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "13aea89a5c93364a98e9b37b2fa237effbb694d5cfe01c5b70941f7eb087d5e3"
 "checksum dirs-sys 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "afa0b23de8fd801745c471deffa6e12d248f962c9fd4b4c33787b055599bde7b"
 "checksum epoll 4.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "990bcfe26bea89669ede68c3f970f61d02568dbc8660317c98d805ea4e710685"
@@ -1412,7 +1419,7 @@ dependencies = [
 "checksum libc 0.2.68 (registry+https://github.com/rust-lang/crates.io-index)" = "dea0c0405123bba743ee3f91f49b1c7cfb684eef0da0a50110f758ccf24cdff0"
 "checksum libssh2-sys 0.2.16 (registry+https://github.com/rust-lang/crates.io-index)" = "7bb70f29dc7c31d32c97577f13f41221af981b31248083e347b7f2c39225a6bc"
 "checksum libz-sys 1.0.25 (registry+https://github.com/rust-lang/crates.io-index)" = "2eb5e43362e38e2bca2fd5f5134c4d4564a23a5c28e9b95411652021a8675ebe"
-"checksum linux-loader 0.1.0 (git+https://github.com/rust-vmm/linux-loader)" = "<none>"
+"checksum linux-loader 0.1.0 (git+https://github.com/michael2012z/linux-loader.git?branch=crab2313-aarch64-image)" = "<none>"
 "checksum lock_api 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "79b2de95ecb4691949fea4716ca53cdbcfccb2c612e19644a8bad05edcf9f47b"
 "checksum log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)" = "e19e8d5c34a3e0e2223db8e060f9e8264aeeb5c5fc64a4ee9965c062211c024b"
 "checksum log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)" = "14b6052be84e6b71ab17edffc2eeabf5c2c3ae1fdb464aae35ac50c67a44e1f7"

--- a/arch/src/aarch64/fdt.rs
+++ b/arch/src/aarch64/fdt.rs
@@ -85,8 +85,8 @@ type Result<T> = result::Result<T, Error>;
 /// Creates the flattened device tree for this aarch64 microVM.
 pub fn create_fdt<T: DeviceInfoForFDT + Clone + Debug>(
     guest_mem: &GuestMemoryMmap,
-    vcpu_mpidr: Vec<u64>,
     cmdline: &CStr,
+    vcpu_mpidr: Vec<u64>,
     device_info: Option<&HashMap<(DeviceType, String), T>>,
     gic_device: &Box<dyn GICDevice>,
     initrd: &Option<InitrdConfig>,
@@ -531,26 +531,8 @@ mod tests {
     use crate::aarch64::gic::create_gic;
     use crate::aarch64::{arch_memory_regions, layout};
     use kvm_ioctls::Kvm;
+    use crate::MMIODeviceInfo;
 
-    const LEN: u64 = 4096;
-
-    #[derive(Clone, Debug)]
-    pub struct MMIODeviceInfo {
-        addr: u64,
-        irq: u32,
-    }
-
-    impl DeviceInfoForFDT for MMIODeviceInfo {
-        fn addr(&self) -> u64 {
-            self.addr
-        }
-        fn irq(&self) -> u32 {
-            self.irq
-        }
-        fn length(&self) -> u64 {
-            LEN
-        }
-    }
     // The `load` function from the `device_tree` will mistakenly check the actual size
     // of the buffer with the allocated size. This works around that.
     fn set_size(buf: &mut [u8], pos: usize, val: usize) {
@@ -573,14 +555,14 @@ mod tests {
             (
                 (DeviceType::Virtio(1), "virtio".to_string()),
                 MMIODeviceInfo {
-                    addr: 0x00 + LEN,
+                    addr: 0x00 + super::LEN,
                     irq: 2,
                 },
             ),
             (
                 (DeviceType::RTC, "rtc".to_string()),
                 MMIODeviceInfo {
-                    addr: 0x00 + 2 * LEN,
+                    addr: 0x00 + 2 * super::LEN,
                     irq: 3,
                 },
             ),

--- a/arch/src/lib.rs
+++ b/arch/src/lib.rs
@@ -79,9 +79,9 @@ pub mod aarch64;
 
 #[cfg(target_arch = "aarch64")]
 pub use aarch64::{
-    arch_memory_regions, configure_system, get_kernel_start, get_reserved_mem_addr,
-    initrd_load_addr, layout, layout::CMDLINE_MAX_SIZE, layout::CMDLINE_START, layout::IRQ_BASE,
-    layout::IRQ_MAX, BootProtocol, EntryPoint, MMIO_MEM_START,
+    arch_memory_regions, configure_system, fdt::DeviceInfoForFDT, get_kernel_start, 
+    get_reserved_mem_addr,initrd_load_addr, layout, layout::CMDLINE_MAX_SIZE, 
+    layout::CMDLINE_START, layout::IRQ_BASE,layout::IRQ_MAX, BootProtocol, EntryPoint, MMIO_MEM_START,
 };
 
 #[cfg(target_arch = "x86_64")]
@@ -120,5 +120,29 @@ pub const PAGE_SIZE: usize = 4096;
 impl fmt::Display for DeviceType {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{:?}", self)
+    }
+}
+
+/// TODO--------------------- meaning to be determined-------
+pub const LEN: u64 = 4096;
+
+/// Structure to describe MMIO device information
+#[derive(Clone, Debug)]
+#[cfg(target_arch = "aarch64")]
+pub struct MMIODeviceInfo {
+    pub addr: u64,
+    pub irq: u32,
+}
+
+#[cfg(target_arch = "aarch64")]
+impl DeviceInfoForFDT for MMIODeviceInfo {
+    fn addr(&self) -> u64 {
+        self.addr
+    }
+    fn irq(&self) -> u32 {
+        self.irq
+    }
+    fn length(&self) -> u64 {
+        LEN
     }
 }

--- a/vmm/src/vm.rs
+++ b/vmm/src/vm.rs
@@ -31,7 +31,15 @@ use crate::cpu;
 use crate::device_manager::{get_win_size, Console, DeviceManager, DeviceManagerError};
 use crate::memory_manager::{get_host_cpu_phys_bits, Error as MemoryManagerError, MemoryManager};
 use anyhow::anyhow;
+#[cfg(target_arch = "aarch64")]
+use arch::aarch64::gic;
 use arch::BootProtocol;
+#[cfg(target_arch = "aarch64")]
+use arch::DeviceType;
+#[cfg(target_arch = "aarch64")]
+use arch::InitrdConfig;
+#[cfg(target_arch = "aarch64")]
+use arch::MMIODeviceInfo;
 use arch::{layout, EntryPoint};
 #[cfg(target_arch = "x86_64")]
 use devices::ioapic;
@@ -41,13 +49,16 @@ use kvm_bindings::kvm_userspace_memory_region;
 #[cfg(target_arch = "x86_64")]
 use kvm_bindings::{kvm_enable_cap, KVM_CAP_SPLIT_IRQCHIP};
 use kvm_ioctls::*;
-#[cfg(target_arch = "x86_64")]
 use linux_loader::cmdline::Cmdline;
 use linux_loader::loader::KernelLoader;
 use signal_hook::{iterator::Signals, SIGINT, SIGTERM, SIGWINCH};
-#[cfg(target_arch = "x86_64")]
+#[cfg(target_arch = "aarch64")]
+use std::collections::HashMap;
 use std::ffi::CString;
 use std::fs::File;
+// Import related with the commented initrd interfaces, to be open in the future.
+//#[cfg(target_arch = "aarch64")]
+//use std::io::{self, Read, Seek, SeekFrom};
 use std::io;
 use std::ops::Deref;
 use std::path::PathBuf;
@@ -55,12 +66,14 @@ use std::sync::{Arc, Mutex, RwLock};
 use std::{result, str, thread};
 #[cfg(target_arch = "x86_64")]
 use vm_allocator::GsiApic;
-
 use vm_allocator::SystemAllocator;
 use vm_device::{Migratable, MigratableError, Pausable, Snapshotable};
 use vm_memory::GuestAddressSpace;
 #[cfg(target_arch = "x86_64")]
 use vm_memory::{Address, Bytes, GuestMemory, GuestMemoryMmap, GuestMemoryRegion};
+// Import related with the commented initrd interfaces, to be open in the future.
+//#[cfg(target_arch = "aarch64")]
+//use vm_memory::{Bytes, GuestMemoryMmap};
 use vm_memory::{GuestAddress, GuestUsize};
 use vmm_sys_util::eventfd::EventFd;
 use vmm_sys_util::terminal::Terminal;
@@ -184,6 +197,12 @@ pub enum Error {
 
     /// No PCI support
     NoPciSupport,
+
+    /// Cannot load initrd due to an invalid memory configuration.
+    InitrdLoad,
+
+    /// Cannot load initrd due to an invalid image.
+    InitrdRead(io::Error),
 }
 pub type Result<T> = result::Result<T, Error>;
 
@@ -230,6 +249,8 @@ impl VmState {
 }
 
 pub struct Vm {
+    #[cfg(target_arch = "aarch64")]
+    fd: Arc<VmFd>,
     kernel: File,
     threads: Vec<thread::JoinHandle<()>>,
     device_manager: Arc<Mutex<DeviceManager>>,
@@ -285,6 +306,7 @@ impl Vm {
             }
             break;
         }
+        
         let fd = Arc::new(fd);
 
         // Set TSS
@@ -394,7 +416,10 @@ impl Vm {
             max_vcpus,
             &device_manager,
             guest_memory,
+            #[cfg(target_arch = "x86_64")]
             fd,
+            #[cfg(target_arch = "aarch64")]
+            fd.clone(),
             #[cfg(target_arch = "x86_64")]
             cpuid,
             reset_evt,
@@ -402,6 +427,8 @@ impl Vm {
         .map_err(Error::CpuManager)?;
 
         Ok(Vm {
+            #[cfg(target_arch = "aarch64")]
+            fd,
             kernel,
             device_manager,
             config,
@@ -415,9 +442,7 @@ impl Vm {
     }
 
     #[cfg(target_arch = "aarch64")]
-    fn load_kernel(&mut self) -> Result<EntryPoint> {
-        // Note, Aarch64 does not write the kernel command line to guest memory.
-        // The command line will be handled via FDT.
+    fn load_kernel_entry(&mut self) -> Result<EntryPoint> {
         let guest_memory = self.memory_manager.lock().as_ref().unwrap().guest_memory();
         let mem = guest_memory.memory();
         let entry_addr = match linux_loader::loader::PE::load(
@@ -430,7 +455,7 @@ impl Vm {
             _ => panic!("Invalid elf file"),
         };
 
-        let boot_vcpus = self.cpu_manager.lock().unwrap().boot_vcpus();
+        let _boot_vcpus = self.cpu_manager.lock().unwrap().boot_vcpus();
         let _max_vcpus = self.cpu_manager.lock().unwrap().max_vcpus();
 
         let mut entry_point_addr: GuestAddress = entry_addr.kernel_load;
@@ -443,12 +468,142 @@ impl Vm {
             BootProtocol::LinuxBoot
         };
 
-        arch::configure_system(&mem, boot_vcpus, boot_prot).map_err(Error::ConfigureSystem)?;
-
         Ok(EntryPoint {
             entry_addr: entry_point_addr,
             protocol: boot_prot,
         })
+    }
+    
+    // Some initrd interfaces to be used in the future integration with real initrd.
+    /*
+    #[cfg(target_arch = "aarch64")]
+    fn load_initrd_from_file(
+        &mut self,
+        initrd_file: &Option<std::fs::File>,
+        vm_memory: &GuestMemoryMmap,
+    ) -> std::result::Result<Option<InitrdConfig>, Error> {
+        use self::Error::InitrdRead;
+
+        Ok(match initrd_file {
+            Some(f) => Some(self.load_initrd(vm_memory, &mut f.try_clone().map_err(InitrdRead)?)?),
+            None => None,
+        })
+    }
+
+    #[cfg(target_arch = "aarch64")]
+    /// Loads the initrd from a file into the given memory slice.
+    ///
+    /// * `vm_memory` - The guest memory the initrd is written to.
+    /// * `image` - The initrd image.
+    ///
+    /// Returns the result of initrd loading
+    fn load_initrd<F>(
+        &mut self,
+        vm_memory: &GuestMemoryMmap,
+        image: &mut F,
+    ) -> std::result::Result<InitrdConfig, Error>
+    where
+        F: Read + Seek,
+    {
+        use self::Error::{InitrdLoad, InitrdRead};
+
+        let size: usize;
+        // Get the image size
+        match image.seek(SeekFrom::End(0)) {
+            Err(e) => return Err(InitrdRead(e)),
+            Ok(0) => {
+                return Err(InitrdRead(io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    "Initrd image seek returned a size of zero",
+                )))
+            }
+            Ok(s) => size = s as usize,
+        };
+        // Go back to the image start
+        image.seek(SeekFrom::Start(0)).map_err(InitrdRead)?;
+
+        // Get the target address
+        let address = arch::initrd_load_addr(vm_memory, size).map_err(|_| InitrdLoad)?;
+
+        // Load the image into memory
+        vm_memory
+            .read_from(GuestAddress(address), image, size)
+            .map_err(|_| InitrdLoad)?;
+
+        Ok(InitrdConfig {
+            address: GuestAddress(address),
+            size,
+        })
+    }
+    */
+
+    #[cfg(target_arch = "aarch64")]
+    fn load_kernel_configure_system(&mut self) -> std::result::Result<(), Error> {
+        let mut cmdline = Cmdline::new(arch::CMDLINE_MAX_SIZE);
+        cmdline
+            .insert_str(self.config.lock().unwrap().cmdline.args.clone())
+            .map_err(Error::CmdLineInsertStr)?;
+        for entry in self.device_manager.lock().unwrap().cmdline_additions() {
+            cmdline.insert_str(entry).map_err(Error::CmdLineInsertStr)?;
+        }
+
+        let cmdline_cstring = CString::new(cmdline).map_err(Error::CmdLineCString)?;
+
+        // Note, Aarch64 does not write the kernel command line to guest memory.
+        // The command line will be handled via FDT.
+        let guest_memory = self.memory_manager.lock().as_ref().unwrap().guest_memory();
+        let mem = guest_memory.memory();
+
+        //let dummy_initrd = load_initrd_from_file(boot_config, &mem)?;
+        let dummy_initrd = InitrdConfig {
+            address: GuestAddress(0x10000000),
+            size: 0x1000,
+        };
+
+        // dummy vcpu_mpidr for place holding ,after integration with vcpu code reorg this can be
+        // changed to real
+        let dummy_vcpu_mpidr = vec![0];
+
+        // dummy device info for place holding, after integration with device manager this can be
+        // changed to real
+        let dummy_dev_info: HashMap<(DeviceType, std::string::String), MMIODeviceInfo> = [
+            (
+                (DeviceType::Serial, DeviceType::Serial.to_string()),
+                MMIODeviceInfo { addr: 0x00, irq: 1 },
+            ),
+            (
+                (DeviceType::Virtio(1), "virtio".to_string()),
+                MMIODeviceInfo {
+                    addr: 0x00 + arch::LEN,
+                    irq: 2,
+                },
+            ),
+            (
+                (DeviceType::RTC, "rtc".to_string()),
+                MMIODeviceInfo {
+                    addr: 0x00 + 2 * arch::LEN,
+                    irq: 3,
+                },
+            ),
+        ]
+        .iter()
+        .cloned()
+        .collect();
+
+        // dummy gic device
+        let dummy_gic = gic::create_gic(&self.fd.clone(), 1).unwrap();
+
+        arch::configure_system(
+            &mem,
+            &cmdline_cstring,
+            dummy_vcpu_mpidr,
+            Some(&dummy_dev_info),
+            &dummy_gic,
+            &Some(dummy_initrd),
+        )
+        .map_err(Error::ConfigureSystem)?;
+        
+        Ok(())
     }
 
     #[cfg(target_arch = "x86_64")]
@@ -736,13 +891,20 @@ impl Vm {
         let new_state = VmState::Running;
         current_state.valid_transition(new_state)?;
 
+        #[cfg(target_arch = "x86_64")]
         let entry_addr = self.load_kernel()?;
+        #[cfg(target_arch = "aarch64")]
+        let entry_addr = self.load_kernel_entry()?;
 
         self.cpu_manager
             .lock()
             .unwrap()
             .start_boot_vcpus(entry_addr)
             .map_err(Error::CpuManager)?;
+
+        #[cfg(target_arch = "aarch64")]
+        // ###Declare another start_boot_vcpus function specificly for aarch64 to pass vcpu out###
+        self.load_kernel_configure_system()?;
 
         if self
             .device_manager


### PR DESCRIPTION
Used some dummy variables to replace un-implemented parameters
such as initrd, vcpu, device_info(device manager), etc.

After these above-mentioned components are implemented for arm,
these dummy variables should be replaced back.

Signed-off-by: Henry Wang <Henry.Wang@arm.com>