### PR TITLE
Add temporary implementation of `get_host_cpu_phys_bits` for arm64

### DIFF
--- a/vmm/src/memory_manager.rs
+++ b/vmm/src/memory_manager.rs
@@ -84,7 +84,7 @@ pub enum Error {
 
 #[cfg(target_arch = "aarch64")]
 pub fn get_host_cpu_phys_bits() -> u8 {
-    panic!("get_host_cpu_phys_bits() not implemented.");
+    48
 }
 
 #[cfg(target_arch = "x86_64")]


### PR DESCRIPTION
As `ID_AA64MMFR0_EL1` register can only be accessed in EL1, for
now hardcode the `get_host_cpu_phys_bits()` function to 48 as a
workaround.

Signed-off-by: Henry Wang <Henry.Wang@arm.com>