### PR TITLE
Change VM boot sequence to cover Aarch64.

### DIFF
--- a/arch/src/aarch64/gic.rs
+++ b/arch/src/aarch64/gic.rs
@@ -19,7 +19,7 @@ pub enum Error {
 type Result<T> = result::Result<T, Error>;
 
 /// Trait for GIC devices.
-pub trait GICDevice {
+pub trait GICDevice: Send + Sync {
     /// Returns the file descriptor of the GIC device
     fn device_fd(&self) -> &DeviceFd;
 

--- a/arch/src/x86_64/mod.rs
+++ b/arch/src/x86_64/mod.rs
@@ -16,6 +16,7 @@ pub mod regs;
 use crate::RegionType;
 use linux_loader::loader::bootparam::{boot_params, setup_header};
 use linux_loader::loader::start_info::{hvm_memmap_table_entry, hvm_start_info};
+use linux_loader::loader::KernelLoaderResult;
 use std::mem;
 use vm_memory::{
     Address, ByteValued, Bytes, GuestAddress, GuestMemory, GuestMemoryMmap, GuestUsize,
@@ -45,6 +46,7 @@ pub struct EntryPoint {
     pub entry_addr: GuestAddress,
     /// Specifies which boot protocol to use
     pub protocol: BootProtocol,
+    pub load_result: KernelLoaderResult,
 }
 
 const E820_RAM: u32 = 1;


### PR DESCRIPTION
The new boot sequence is:
- create vcpus
- configure vcpus
- (ARM) setup IRQCHIP
- (ARM) setup legacy devices irq_fd 
- configure_system (Aarch64 create fdt here)
- start_vcpus

In the very basic launching test, X86 functionality is not broken.

Signed-off-by: Michael Zhao <michael.zhao@arm.com>